### PR TITLE
Removing all use of v62.

### DIFF
--- a/Trans_Sys.v
+++ b/Trans_Sys.v
@@ -61,13 +61,13 @@ Lemma deriv_weak_deriv :
  forall (p p' : process) (a : action),
  derivative p a p' -> weak_derivative p a p'.
 
-intros p p' a H; elim H; clear H; auto with v62.
+intros p p' a H; elim H; clear H; auto .
 clear p p' a.
 intros a p p' q tr de we.
-apply w_tau_left with p'; try trivial with v62.
+apply w_tau_left with p'; try trivial .
 
 clear p p' a; intros a p q q' tr de we.
-apply w_tau_right with q'; try trivial with v62.
+apply w_tau_right with q'; try trivial .
 
 Qed.
 
@@ -78,16 +78,16 @@ Lemma weak_deriv_deriv :
  weak_derivative p a p' -> a <> T -> derivative p a p'.
 intros p p' a H; elim H; clear H p p' a.
 unfold not in |- *.
-intros p H; cut False; auto with v62.
+intros p H; cut False; auto .
 intros H1; elim H1.
 
-intros a p q tr H; auto with v62.
+intros a p q tr H; auto .
 
 intros a p p' q tr we H_ind not_eq.
-apply tau_left with p'; auto with v62.
+apply tau_left with p'; auto .
 
 intros a p q q' tr we H_ind notEq.
-apply tau_right with q'; auto with v62.
+apply tau_right with q'; auto .
 Qed.
 
 Hint Resolve weak_deriv_deriv.
@@ -103,24 +103,24 @@ cut
   a = T ->
   forall (p'' : process) (b : action),
   weak_derivative p' b p'' -> weak_derivative p b p'').
-intros H p p' p'' a we we'; apply (H p T p'); auto with v62.
+intros H p p' p'' a we we'; apply (H p T p'); auto .
 
 simple induction 1.
-simple induction 1; auto with v62.
+simple induction 1; auto .
 
 clear H p' a p.
 intros a p q Tpq eqT p'' b we.
 rewrite eqT in Tpq.
-apply w_tau_left with q; auto with v62.
+apply w_tau_left with q; auto .
 
 clear H p p' a.
 intros a p p' q Tpq we H_rec eqT p'' b we'.
-apply w_tau_left with p'; auto with v62.
+apply w_tau_left with p'; auto .
 
 clear H p a p'.
 intros a p q q' Tr we H_rec eqT p'' b we'.
 apply (H_rec eqT).
-apply w_tau_left with q; auto with v62.
+apply w_tau_left with q; auto .
 
 Qed.
 
@@ -135,19 +135,19 @@ cut
   a = T ->
   forall (p : process) (b : action),
   weak_derivative p b p' -> weak_derivative p b p'').
-intros H p p' p'' a we we1; apply (H p' T p''); auto with v62.
+intros H p p' p'' a we we1; apply (H p' T p''); auto .
 
-intros p' a p'' H; elim H; clear H a p' p''; auto with v62.
+intros p' a p'' H; elim H; clear H a p' p''; auto .
 intros a p q tr eqT p0 b we.
-apply w_tau_right with p; auto with v62.
-rewrite eqT in tr; auto with v62.
+apply w_tau_right with p; auto .
+rewrite eqT in tr; auto .
 
 intros a p q q' tr we H_rec eqT p0 b we'.
 apply (H_rec eqT).
-apply w_tau_right with p; auto with v62.
+apply w_tau_right with p; auto .
 
 intros a p q q' tr we H_rec eqT p0 b we'.
-apply w_tau_right with q'; auto with v62.
+apply w_tau_right with q'; auto .
 
 Qed.
 
@@ -162,19 +162,19 @@ cut
   a = T ->
   forall (p'' : process) (b : action),
   derivative p' b p'' -> derivative p b p'').
-intros H p p' p'' a de de1; apply (H p T p'); auto with v62.
+intros H p p' p'' a de de1; apply (H p T p'); auto .
 
-intros p a p' H; elim H; clear H a p p'; auto with v62.
+intros p a p' H; elim H; clear H a p p'; auto .
 intros a p q Tpq eqT p'' b de.
 rewrite eqT in Tpq.
-apply tau_left with q; auto with v62.
+apply tau_left with q; auto .
 
 intros a p p' q tr de H_ind eqT p'' d de'.
-apply tau_left with p'; auto with v62.
+apply tau_left with p'; auto .
 
 intros a p q q' Tr de H_ind eqT p'' b de'.
 apply (H_ind eqT).
-apply tau_left with q; auto with v62.
+apply tau_left with q; auto .
 
 Qed.
 
@@ -187,21 +187,21 @@ cut
   weak_derivative p' a p'' ->
   a = T ->
   forall (p : process) (b : action), derivative p b p' -> derivative p b p'').
-intros H p p' p'' a de de1; apply (H p' T p''); auto with v62.
+intros H p p' p'' a de de1; apply (H p' T p''); auto .
 
 intros p' a p'' H; elim H; clear H a p' p''.
-auto with v62.
+auto .
 
 intros a p q tr eqT p0 b we.
-apply tau_right with p; auto with v62.
-rewrite eqT in tr; auto with v62.
+apply tau_right with p; auto .
+rewrite eqT in tr; auto .
 
 intros a p q q' tr we H_rec eqT p0 b we'.
 apply (H_rec eqT).
-apply tau_right with p; auto with v62.
+apply tau_right with p; auto .
 
 intros a p q q' tr we H_rec eqT p0 b we'.
-apply tau_right with q'; auto with v62.
+apply tau_right with q'; auto .
 
 Qed.
 
@@ -210,7 +210,7 @@ Lemma deriv_tau_left :
  derivative p T p' -> derivative p' a p'' -> derivative p a p''.
 
 intros p p' p'' a pp' p_p''.
-apply w_deriv_tau_left with p'; auto with v62.
+apply w_deriv_tau_left with p'; auto .
 Qed.
 
 Lemma deriv_tau_right :
@@ -218,7 +218,7 @@ Lemma deriv_tau_right :
  derivative p a p' -> derivative p' T p'' -> derivative p a p''.
 
 intros p p' p'' a de1 de2.
-apply w_deriv_tau_right with p'; auto with v62.
+apply w_deriv_tau_right with p'; auto .
 Qed.
 
 (************************* Strong equivalence ******************************)
@@ -240,8 +240,8 @@ CoInductive strong_eq : process -> process -> Prop :=
 Lemma refl_strong_eq : forall p : process, strong_eq p p.
 cofix.
 intros p; apply str_eq.
-intros a p' trans; exists p'; split; auto with v62.
-intros a p' trans; exists p'; split; auto with v62.
+intros a p' trans; exists p'; split; auto .
+intros a p' trans; exists p'; split; auto .
 Qed.
 
 Hint Resolve refl_strong_eq.
@@ -253,12 +253,12 @@ apply str_eq.
 intros a q'.
 intros trans.
 elim (H1 a q' trans); clear H1.
-intros p' H; elim H; exists p'; split; auto with v62.
+intros p' H; elim H; exists p'; split; auto .
 intros a p' trans.
 elim (H0 a p' trans); clear H0.
 intros q' H; elim H; clear H.
 intros trans1 str.
-exists q'; split; auto with v62.
+exists q'; split; auto .
 Qed.
 
 Hint Immediate sym_strong_eq.
@@ -277,12 +277,12 @@ intros q' G; elim G.
 intros tq pq'; elim (H1 a q' tq).
 clear G.
 intros r' G; elim G; clear G.
-intros tr qr'; exists r'; split; auto with v62.
-apply trans_strong_eq with q'; auto with v62.
+intros tr qr'; exists r'; split; auto .
+apply trans_strong_eq with q'; auto .
 elim (H a p' tp).
 intros q' G; elim G; clear G.
 intros tq pq'.
-exists q'; split; auto with v62.
+exists q'; split; auto .
 intros a r' tr.
 cut (exists q' : process, transition q a q' /\ strong_eq q' r').
 intros G; elim G; clear G.
@@ -290,11 +290,11 @@ intros q' G; elim G; clear G.
 intros tq qr'.
 elim (H0 a q' tq).
 intros p' G; elim G; clear G.
-intros tp pq'; exists p'; split; auto with v62.
-apply trans_strong_eq with q'; auto with v62.
+intros tp pq'; exists p'; split; auto .
+apply trans_strong_eq with q'; auto .
 elim (H2 a r' tr).
 intros q' G; elim G; clear G.
-intros tq qr'; exists q'; split; auto with v62.
+intros tq qr'; exists q'; split; auto .
 Qed.
 
 (**************************** Weak equivalence *****************************)
@@ -315,8 +315,8 @@ CoInductive weak_eq : process -> process -> Prop :=
 Lemma refl_weak_eq : forall p : process, weak_eq p p.
 cofix.
 intros p; apply w_eq.
-intros a p' trans; exists p'; split; auto with v62.
-intros a p' trans; exists p'; split; auto with v62.
+intros a p' trans; exists p'; split; auto .
+intros a p' trans; exists p'; split; auto .
 Qed.
 
 Hint Resolve refl_weak_eq.
@@ -328,12 +328,12 @@ apply w_eq.
 intros a q'.
 intros trans.
 elim (H1 a q' trans); clear H1.
-intros p' H; elim H; exists p'; split; auto with v62.
+intros p' H; elim H; exists p'; split; auto .
 intros a p' trans.
 elim (H0 a p' trans); clear H0.
 intros q' H; elim H; clear H.
 intros trans1 str.
-exists q'; split; auto with v62.
+exists q'; split; auto .
 Qed.
 
 Hint Immediate sym_weak_eq.
@@ -350,7 +350,7 @@ Remark Hint_Trans :
 intros q q' r a H.
 generalize r; clear r.
 elim H; clear H.
-intros p r we; exists r; split; auto with v62.
+intros p r we; exists r; split; auto .
 
 clear a q q'; intros a p q tr r we.
 inversion_clear we.
@@ -364,13 +364,13 @@ intros r'' Hr''; elim Hr''; clear Hr''; intros rTr'' we'.
 cut (exists r' : process, weak_derivative r'' a r' /\ weak_eq q r').
 intros H; elim H; clear H.
 intros r' Hr'; elim Hr'; clear Hr'; intros wde we''.
-exists r'; split; auto with v62.
-apply (weak_deriv_tau_left r r'' r' a); auto with v62.
+exists r'; split; auto .
+apply (weak_deriv_tau_left r r'' r' a); auto .
 
-apply (H_ind r''); auto with v62.
+apply (H_ind r''); auto .
 
 inversion_clear we.
-apply (H T p' tr); auto with v62.
+apply (H T p' tr); auto .
 
 clear q q' a; intros a p q q' tr wd H_ind r we.
 cut (exists r'' : process, weak_derivative r a r'' /\ weak_eq q' r'').
@@ -379,12 +379,12 @@ intros r'' Hr''; elim Hr''; clear Hr''; intros wd' we'.
 cut (exists r' : process, weak_derivative r'' T r' /\ weak_eq q r').
 intros H; elim H; clear H.
 intros r' Hr'; elim Hr'; intros wd'' we''.
-exists r'; split; auto with v62.
-apply (weak_deriv_tau_right r r'' r' a); auto with v62.
+exists r'; split; auto .
+apply (weak_deriv_tau_right r r'' r' a); auto .
 
-inversion_clear we'; auto with v62.
+inversion_clear we'; auto .
 
-apply (H_ind r we); auto with v62.
+apply (H_ind r we); auto .
 
 Qed.
 
@@ -400,20 +400,20 @@ intros H; elim H; clear H; intros q' Hq'; elim Hq'; clear Hq'; intros wd we.
 cut (exists r' : process, weak_derivative r a r' /\ weak_eq q' r').
 intros Hr'; elim Hr'; clear Hr'; intros r' Hr'; elim Hr'; clear Hr';
  intros wd' we'.
-exists r'; split; auto with v62.
-apply trans_weak_eq with q'; auto with v62.
-apply (Hint_Trans q q' r); auto with v62.
-inversion_clear pq; auto with v62.
+exists r'; split; auto .
+apply trans_weak_eq with q'; auto .
+apply (Hint_Trans q q' r); auto .
+inversion_clear pq; auto .
 
 intros a r' tr.
 cut (exists q' : process, weak_derivative q a q' /\ weak_eq q' r').
 intros H; elim H; clear H; intros q' Hq'; elim Hq'; clear Hq'; intros wd we.
 cut (exists p' : process, weak_derivative p a p' /\ weak_eq q' p').
 intros H; elim H; clear H; intros p' Hp'; elim Hp'; clear Hp'; intros wd' we'.
-exists p'; split; auto with v62.
-apply trans_weak_eq with q'; auto with v62.
-apply (Hint_Trans q q' p a); auto with v62.
-inversion_clear qr; auto with v62.
+exists p'; split; auto .
+apply trans_weak_eq with q'; auto .
+apply (Hint_Trans q q' p a); auto .
+inversion_clear qr; auto .
 Qed.
 
 
@@ -455,13 +455,13 @@ intros q1 H; elim H; clear H; intros wde we'.
 cut (exists q' : process, weak_derivative q1 a q' /\ weak_eq p' q').
 intros H; elim H; clear H.
 intros q' H; elim H; clear H; intros wde1 we1.
-exists q'; split; try try try trivial with v62.
-apply weak_deriv_tau_left with q1; try try trivial with v62.
+exists q'; split; try try try trivial .
+apply weak_deriv_tau_left with q1; try try trivial .
 
-apply (H_ind q1); try try trivial with v62.
+apply (H_ind q1); try try trivial .
 
 inversion_clear we.
-apply (H T p1); try try trivial with v62.
+apply (H T p1); try try trivial .
 
 intros a p p' p1 tr de H_ind q we.
 cut (exists q1 : process, weak_derivative q a q1 /\ weak_eq p1 q1).
@@ -470,11 +470,11 @@ intros q1 H; elim H; clear H; intros wde we1.
 cut (exists q' : process, weak_derivative q1 T q' /\ weak_eq p' q').
 intros H; elim H; clear H.
 intros q' H; elim H; clear H; intros wde1 we'.
-exists q'; split; try try try trivial with v62.
-apply weak_deriv_tau_right with q1; try try trivial with v62.
+exists q'; split; try try try trivial .
+apply weak_deriv_tau_right with q1; try try trivial .
 
 inversion_clear we1.
-apply (H T p'); try try trivial with v62.
+apply (H T p'); try try trivial .
 
 apply (H_ind q we).
 Qed.
@@ -487,11 +487,11 @@ Lemma weak_eq_deriv_sym :
  exists p' : process, weak_derivative p a p' /\ weak_eq p' q'.
 
 intros p q we a q' de.
-cut (weak_eq q p); auto with v62.
+cut (weak_eq q p); auto .
 intros we'.
 elim (weak_eq_deriv q p we' a q' de).
 intros p' H; elim H; intros w_de we''.
-exists p'; split; auto with v62.
+exists p'; split; auto .
 
 Qed.
 
@@ -504,7 +504,7 @@ intros a p' tr.
 inversion we1.
 elim (H a p').
 intros q' G; elim G; clear G; intros wde we1'.
-exists q'; split; try try try trivial with v62.
+exists q'; split; try try try trivial .
 apply weak_eq1_weak_eq; assumption.
 
 apply single; assumption.
@@ -513,10 +513,10 @@ intros a q' tr.
 inversion we1.
 elim (H0 a q').
 intros p' G; elim G; intros wde we1'.
-exists p'; split; try try try trivial with v62.
+exists p'; split; try try try trivial .
 apply weak_eq1_weak_eq; assumption.
 
-apply single; try try trivial with v62.
+apply single; try try trivial .
 Qed.
 
 Hint Immediate weak_eq1_weak_eq.
@@ -530,8 +530,8 @@ intros a p' de.
 cut (exists q' : process, weak_derivative q a q' /\ weak_eq p' q').
 intros H; elim H; clear H.
 intros q' H; elim H; clear H; intros wde we'.
-exists q'; split; try try try trivial with v62.
-apply weak_eq_weak_eq1; try try trivial with v62.
+exists q'; split; try try try trivial .
+apply weak_eq_weak_eq1; try try trivial .
 
 elim (weak_eq_deriv p q we a p' de).
 intros q' H; exists q'; assumption.
@@ -540,8 +540,8 @@ intros a q' de.
 cut (exists p' : process, weak_derivative p a p' /\ weak_eq p' q').
 intros H; elim H; clear H.
 intros p' H; elim H; clear H; intros wde we'.
-exists p'; split; try try try try trivial with v62.
-apply weak_eq_weak_eq1; try try try trivial with v62.
+exists p'; split; try try try try trivial .
+apply weak_eq_weak_eq1; try try try trivial .
 
 elim (weak_eq_deriv_sym p q we a q' de).
 intros p' H; exists p'; assumption.
@@ -555,14 +555,14 @@ Hint Immediate weak_eq_weak_eq1.
 
 Lemma refl_weak_eq1 : forall p : process, weak_eq1 p p.
 
-auto with v62.
+auto .
 Qed.
 
 Lemma sym_weak_eq1 : forall p q : process, weak_eq1 p q -> weak_eq1 q p.
 
 intros.
 apply weak_eq_weak_eq1.
-apply sym_weak_eq; auto with v62.
+apply sym_weak_eq; auto .
 
 Qed.
 
@@ -571,7 +571,7 @@ Lemma trans_weak_eq1 :
 
 intros p q r pq qr.
 apply weak_eq_weak_eq1.
-apply trans_weak_eq with q; auto with v62.
+apply trans_weak_eq with q; auto .
 
 Qed.
 
@@ -587,7 +587,7 @@ Definition obs_eq (p q : process) : Prop :=
 
 Lemma refl_obs_eq : forall p : process, obs_eq p p.
 unfold obs_eq in |- *.
-split; intros a p' trans; exists p'; split; auto with v62.
+split; intros a p' trans; exists p'; split; auto .
 Qed.
 
 Hint Immediate refl_obs_eq.
@@ -597,13 +597,13 @@ unfold obs_eq in |- *.
 intros p q.
 intros H; elim H; clear H; intros Hp Hq.
 split.
-auto with v62.
+auto .
 intros a q' tr.
 elim (Hq a q' tr); clear Hq.
-intros p' H; elim H; clear H; intros de we; exists p'; split; auto with v62.
+intros p' H; elim H; clear H; intros de we; exists p'; split; auto .
 intros a p' tr.
 elim (Hp a p' tr); clear Hp.
-intros q' H; elim H; clear H; intros de we; exists q'; split; auto with v62.
+intros q' H; elim H; clear H; intros de we; exists q'; split; auto .
 Qed.
 
 Hint Immediate sym_obs_eq.
@@ -623,7 +623,7 @@ Definition obs_eq1 (p q : process) : Prop :=
 
 Lemma obs_eq1_obs_eq : forall p q : process, obs_eq1 p q -> obs_eq p q.
 intros p q oe.
-unfold obs_eq in |- *; split; elim oe; auto with v62.
+unfold obs_eq in |- *; split; elim oe; auto .
 Qed.
 
 Hint Resolve obs_eq1_obs_eq.
@@ -638,7 +638,7 @@ intros p q oe a p' de; generalize oe; generalize q; clear oe q.
 elim de; clear de a p p'.
 intros a p p' tr q oe.
 unfold obs_eq in oe; elim oe; clear oe; intros oe_l oe_r; clear oe_r.
-auto with v62.
+auto .
 
 intros a p p1 p' tr de H_ind q oe.
 cut (exists q1 : process, derivative q T q1 /\ weak_eq p1 q1).
@@ -647,28 +647,28 @@ intros q1 H; elim H; clear H; intros de' we.
 cut (exists q' : process, weak_derivative q1 a q' /\ weak_eq p' q').
 intros H; elim H; clear H.
 intros q' H; elim H; intros de'' we'.
-exists q'; split; auto with v62.
+exists q'; split; auto .
 elim eqT_dec with a.
 intros a_T.
 rewrite a_T in de''.
 rewrite a_T.
-apply w_deriv_tau_right with q1; auto with v62.
+apply w_deriv_tau_right with q1; auto .
 
 intros dif_a_T.
 apply weak_deriv_deriv.
-apply weak_deriv_tau_left with q1; auto with v62.
+apply weak_deriv_tau_left with q1; auto .
 
-auto with v62.
+auto .
 
-cut (weak_eq1 p1 q1); auto with v62.
+cut (weak_eq1 p1 q1); auto .
 intros we1.
 cut (exists q' : process, weak_derivative q1 a q' /\ weak_eq1 p' q').
 intros H; elim H; clear H; intros q' H; elim H; intros de'' we1'; exists q';
- split; auto with v62.
+ split; auto .
 
-inversion_clear we1; auto with v62.
+inversion_clear we1; auto .
 
-unfold obs_eq in oe; elim oe; auto with v62.
+unfold obs_eq in oe; elim oe; auto .
 
 intros a p p' p1 tr de H_ind q oe.
 cut (exists q1 : process, derivative q a q1 /\ weak_eq p1 q1).
@@ -676,12 +676,12 @@ intros H; elim H; clear H.
 intros q1 H; elim H; clear H; intros de1 we1.
 cut (exists q' : process, weak_derivative q1 T q' /\ weak_eq p' q').
 intros H; elim H; clear H; intros q' H; elim H; intros de2 we.
-exists q'; split; auto with v62.
-apply w_deriv_tau_right with q1; auto with v62.
+exists q'; split; auto .
+apply w_deriv_tau_right with q1; auto .
 
-inversion_clear we1; auto with v62.
+inversion_clear we1; auto .
 
-apply (H_ind q); auto with v62.
+apply (H_ind q); auto .
 
 Qed.
 
@@ -697,9 +697,9 @@ cut
   exists p' : process, derivative p a p' /\ weak_eq q' p').
 intros H a q' de.
 elim (H a q' de); clear H.
-intros p' H; elim H; clear H; intros; exists p'; split; auto with v62.
+intros p' H; elim H; clear H; intros; exists p'; split; auto .
 
-cut (obs_eq q p); auto with v62.
+cut (obs_eq q p); auto .
 exact (half_obs_eq_obs_eq1 q p).
 
 Qed.
@@ -710,7 +710,7 @@ Hint Resolve obs_eq_obs_eq1.
 
 Lemma refl_obs_eq1 : forall p : process, obs_eq1 p p.
 
-auto with v62.
+auto .
 Qed.
 
 Hint Immediate refl_obs_eq1.
@@ -719,7 +719,7 @@ Lemma sym_obs_eq1 : forall p q : process, obs_eq1 p q -> obs_eq1 q p.
 intros.
 apply obs_eq_obs_eq1.
 apply sym_obs_eq.
-auto with v62.
+auto .
 Qed.
 
 Hint Immediate sym_obs_eq1.
@@ -737,10 +737,10 @@ intros H; elim H; clear H; intros q' H; elim H; intros de' we; clear H.
 elim qr; clear qr; intros qr_l qr_r; clear qr_r.
 elim (qr_l a q' de').
 intros r' H; elim H; clear H; intros de'' we'; exists r'; split;
- auto with v62.
-apply trans_weak_eq with q'; auto with v62.
+ auto .
+apply trans_weak_eq with q'; auto .
 
-elim pq; intros pq_l pq_r; clear pq_r; auto with v62.
+elim pq; intros pq_l pq_r; clear pq_r; auto .
 
 Qed.
 
@@ -756,10 +756,10 @@ cut
   exists p' : process, derivative p a p' /\ weak_eq r' p').
 intros H a r' de.
 elim (H a r' de); clear H; intros p' H; elim H; clear H; intros; exists p';
- split; auto with v62.
+ split; auto .
 
-cut (obs_eq1 q p); auto with v62.
-cut (obs_eq1 r q); auto with v62.
+cut (obs_eq1 q p); auto .
+cut (obs_eq1 r q); auto .
 exact (half_trans_obs_eq1 r q p).
 Qed.
 
@@ -767,7 +767,7 @@ Lemma trans_obs_eq :
  forall p q r : process, obs_eq p q -> obs_eq q r -> obs_eq p r.
 intros p q r pq qr.
 apply obs_eq1_obs_eq.
-apply trans_obs_eq1 with q; auto with v62.
+apply trans_obs_eq1 with q; auto .
 
 Qed.
 
@@ -787,18 +787,18 @@ intros trans1 Str.
 exists q'.
 split.
 apply w_single.
-try try trivial with v62.
+try try trivial .
 
-apply strong_weak; try try trivial with v62.
+apply strong_weak; try try trivial .
 
 clear H0.
 intros a q' trans.
 elim (H1 a q' trans); clear H1.
 intros p' H; elim H; clear H.
 intros trans1 Str; exists p'; split.
-apply w_single; try try trivial with v62.
+apply w_single; try try trivial .
 
-apply strong_weak; try try trivial with v62.
+apply strong_weak; try try trivial .
 Qed.
 
 Hint Resolve strong_weak.
@@ -811,11 +811,11 @@ unfold obs_eq in |- *; split.
 clear H1; intros a p' trans.
 elim (H0 a p' trans); clear H0.
 intros q' H; elim H; clear H.
-intros trans1 Str; exists q'; auto with v62.
+intros trans1 Str; exists q'; auto .
 clear H0; intros a q' trans.
 elim (H1 a q' trans); clear H1.
 intros p' H; elim H; clear H.
-intros trans1 Str; exists p'; split; auto with v62.
+intros trans1 Str; exists p'; split; auto .
 Qed.
 
 Hint Resolve strong_obs.
@@ -828,11 +828,11 @@ apply w_eq.
 intros a p' tr.
 elim (H1 a p' tr).
 intros q' H; elim H; clear H; intros de we.
-exists q'; split; auto with v62.
+exists q'; split; auto .
 intros a q' tr.
 elim (H2 a q' tr).
 intros p' H; elim H; clear H; intros de we.
-exists p'; split; auto with v62.
+exists p'; split; auto .
 Qed.
 
 


### PR DESCRIPTION
This was as simple as:

```
$ for f in *.v; do sed -e "s/with v62//g" $f > ${f}_new; mv ${f}_new $f; done
```
